### PR TITLE
[JENKINS-35286] Upgrade to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,34 +20,16 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.625.3</jenkins.version> <!-- 1.577 -->
-    <!--<jenkins-test-harness.version>2.6</jenkins-test-harness.version>-->
+    <jenkins.version>1.625.3</jenkins.version>
   </properties>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version> <!-- Try bumping to 3.0.3 & see if it passes -->
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-          <failOnError>true</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase> 
-            <goals>
-              <goal>check</goal> 
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  
   <licenses>
     <license>
       <name>The MIT license</name>
@@ -55,5 +37,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,20 +20,21 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>1.577</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.577</version>
+    <version>2.9</version>
   </parent>
 
   <artifactId>javadoc</artifactId>
@@ -19,21 +19,17 @@
     <tag>HEAD</tag>
   </scm>
   
-  <dependencies>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
+  <properties>
+    <jenkins.version>1.625.3</jenkins.version> <!-- 1.577 -->
+    <!--<jenkins-test-harness.version>2.6</jenkins-test-harness.version>-->
+  </properties>
   
   <build>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1</version> <!-- Try bumping to 3.0.3 & see if it passes -->
         <configuration>
           <xmlOutput>true</xmlOutput>
           <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
@@ -52,13 +48,6 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
-
   <licenses>
     <license>
       <name>The MIT license</name>
@@ -66,12 +55,5 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.577</jenkins.version>
+    <jenkins.version>1.580.1</jenkins.version>
     <java.level>6</java.level>
   </properties>
 
@@ -42,7 +42,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>  


### PR DESCRIPTION
[JENKINS-35286](https://issues.jenkins-ci.org/browse/JENKINS-35286)

Upgrade to new parent pom. More info [here](https://github.com/jenkinsci/plugin-pom).

- [x] Upgrade to new parent pom
- [x] Remove inherit plugin configuration
- [x] Update maven repositories

@reviewbybees 