### PR TITLE
Update parent pom and plugin requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>3.28</version>
   </parent>
 
   <artifactId>javadoc</artifactId>
@@ -20,8 +20,8 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.1</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.625.1</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.28</version>
+    <version>3.36</version>
   </parent>
 
   <artifactId>javadoc</artifactId>


### PR DESCRIPTION
Updating only the parent version created error with enforcer-rule. Had to update `java.version` at least. But as `1.580.1` is not supposed to be ran with Java `1.6`, I also updated the version of Jenkins Core. 

@jenkinsci/java11-support 