### PR TITLE
Move docs from Wiki to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+# Changelog
 
 ### Version 1.5 (Mar 06, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Change Log
+
+### Version 1.5 (Mar 06, 2019)
+
+-   [JENKINS-32619](https://issues.jenkins-ci.org/browse/JENKINS-32619) -
+    Fix javadoc presentation for java 11 generated reports
+-   Update the Jenkins core requirement to 2.60,3
+
+### Version 1.4 (Jun 17, 2016)
+
+-   [JENKINS-32619](https://issues.jenkins-ci.org/browse/JENKINS-32619)
+    Compatibility with content security policy enforced as part of a
+    Jenkins security update.
+
+### Version 1.3 (Nov 06, 2014)
+
+No code change from beta 2.
+
+### Version 1.3-beta-2 (Oct 20, 2014)
+
+-   Fixed error in form validation when used in a context other than a
+    freestyle project.
+
+### Version 1.3-beta-1 (Aug 25, 2014)
+
+-   [JENKINS-23713](https://issues.jenkins-ci.org/browse/JENKINS-23713)
+    Taking advantage of 1.577+ APIs.
+
+### Version 1.2 (Jul 31, 2014)
+
+-   Fix to serialized form of build action.
+
+### Version 1.1 (Feb 20, 2013)
+
+-   translations
+-   label for Plugin Manager
+
+### Version 1.0 (Sep 19, 2011)
+
+-   First release, split off from the core.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,40 @@
 # Changelog
 
-### Version 1.5 (Mar 06, 2019)
+## Version 1.5 (Mar 06, 2019)
 
 -   [JENKINS-32619](https://issues.jenkins-ci.org/browse/JENKINS-32619) -
     Fix javadoc presentation for java 11 generated reports
 -   Update the Jenkins core requirement to 2.60,3
 
-### Version 1.4 (Jun 17, 2016)
+## Version 1.4 (Jun 17, 2016)
 
 -   [JENKINS-32619](https://issues.jenkins-ci.org/browse/JENKINS-32619)
     Compatibility with content security policy enforced as part of a
     Jenkins security update.
 
-### Version 1.3 (Nov 06, 2014)
+## Version 1.3 (Nov 06, 2014)
 
 No code change from beta 2.
 
-### Version 1.3-beta-2 (Oct 20, 2014)
+## Version 1.3-beta-2 (Oct 20, 2014)
 
 -   Fixed error in form validation when used in a context other than a
     freestyle project.
 
-### Version 1.3-beta-1 (Aug 25, 2014)
+## Version 1.3-beta-1 (Aug 25, 2014)
 
 -   [JENKINS-23713](https://issues.jenkins-ci.org/browse/JENKINS-23713)
     Taking advantage of 1.577+ APIs.
 
-### Version 1.2 (Jul 31, 2014)
+## Version 1.2 (Jul 31, 2014)
 
 -   Fix to serialized form of build action.
 
-### Version 1.1 (Feb 20, 2013)
+## Version 1.1 (Feb 20, 2013)
 
 -   translations
 -   label for Plugin Manager
 
-### Version 1.0 (Sep 19, 2011)
+## Version 1.0 (Sep 19, 2011)
 
 -   First release, split off from the core.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Jenkins Javadoc Plugin
+
+[![Build Status](https://ci.jenkins.io/job/Plugins/job/javadoc-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/javadoc-plugin/job/master/)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/javadoc-plugin.svg)](https://github.com/jenkinsci/javadoc-plugin/graphs/contributors)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/javadoc.svg)](https://plugins.jenkins.io/javadoc)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/javadoc.svg?color=blue)](https://plugins.jenkins.io/javadoc)
+[![Gitter](https://badges.gitter.im/jenkinsci/jenkins.svg)](https://gitter.im/jenkinsci/jenkins)
+
+This plugin adds Javadoc support to Jenkins.
+This functionality used to be a part of the core, but as of Jenkins 1.431, it was split off into a separate plugin.
+
+The plugin enables the selection of "Publish Javadoc" as Post-build action, specifying the directory where the Javadoc is to be gathered and if retention is expected for each successful build.
+
+## Changelog
+
+See the [CHANGELOG](CHANGELOG.md) for the plugin release history.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <packaging>hpi</packaging>
   <name>Javadoc Plugin</name>
 
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Javadoc+Plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>


### PR DESCRIPTION
## Move docs from Wiki to GitHub

Changed the URL in the pom to refer to GitHub.  Extracted a changelog from the Wiki.  Extracted and updated README from the Wiki.