### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,11 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  // Run a JVM per core in tests
+  forkCount: '1C',
+  useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21, jenkins: '2.414'],
     [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
     <jenkins.version>2.361.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <spotless.check.skip>false</spotless.check.skip>
+    <!-- TODO: Enable spotless when Java 21 issue is fixed -->
+    <!-- <spotless.check.skip>false</spotless.check.skip> -->
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Test with Java 21

Temporarily disable spotless formatting because it fails on Java 21.

If it is a long term problem, we could define a maven profile that disables spotless on Java 21 and continues to run it on the other Java versions.

### Testing done

Confirmed that tests pass with Java 21 on my Linux computer

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
