### PR TITLE
Enable spotless again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     <jenkins.version>2.361.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
-    <!-- TODO: Enable spotless when Java 21 issue is fixed -->
-    <!-- <spotless.check.skip>false</spotless.check.skip> -->
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Enable spotless again

Parent pom 4.72 is needed for spotless on Java 21.

Thanks @NotMyFault for detecting my issue!

### Testing done

Confirmed that `mvn spotless:apply` works as expected on the pom.xml file and on Java files with Java 21 early access.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
