### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
@@ -43,8 +43,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>2982.vdce2153031a_0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

As of 19 Apr 2024, 70% of the installations of the most recent release (243.vb_b_503b_b_45537 - released 9 months ago) are using Jenkins 2.426.3 or newer.  Users that are upgrading the plugin version are also upgrading their version of Jenkins core.

Jenkins 2.426.3 is the first version with the fix for https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314, the arbitrary file read vulnerability through the CLI can lead to RCE. It is a very good choice as a minimum Jenkins version.

Jenkins 2.426.3 is one of the versions suggested by https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

### Testing done

Already actively using the plugin in my Jenkins 2.440.3 and later.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
