### PR TITLE
Add top level help and javadocDir argument help

### DIFF
--- a/src/main/resources/hudson/tasks/JavadocArchiver/help-javadocDir.html
+++ b/src/main/resources/hudson/tasks/JavadocArchiver/help-javadocDir.html
@@ -1,0 +1,3 @@
+<div>
+    Directory that contains the Javadoc that is to be published for the build.
+</div>

--- a/src/main/resources/hudson/tasks/JavadocArchiver/help.html
+++ b/src/main/resources/hudson/tasks/JavadocArchiver/help.html
@@ -1,0 +1,9 @@
+<div>
+    Adds <a href="https://www.oracle.com/java/technologies/javase/javadoc-tool.html">Javadoc</a> support to Jenkins jobs.
+
+    <p>
+    The plugin provides a "Publish Javadoc" post-build action, specifying the directory where the Javadoc is to be gathered and if retention is expected for each successful build.
+
+    <p>
+    Pipeline jobs can publish Javadoc using the <a href="https://www.jenkins.io/doc/pipeline/steps/javadoc/">javadoc step.</a>
+</div>


### PR DESCRIPTION
## Add top level help and javadocDir argument help

Add help for the top level javadoc Pipeline step and its matching online help.  Also add help for the javadocDir argument to the Pipeline step.

Improves the content of online help and the [Pipeline steps reference](https://www.jenkins.io/doc/pipeline/steps/javadoc/).

### Testing done

Ran Jenkins interactively and confirmed that help is visible for both freestyle jobs and Pipeline jobs.

### Freestyle help

The freestyle help looks like this:

![freestyle-javadoc-help](https://github.com/user-attachments/assets/61311d24-3d4a-45f5-9080-b3cd505d0536)

#### Pipeline help

The Pipeline help looks like this

![pipeline-javadoc-help](https://github.com/user-attachments/assets/99ecb3b3-fc2a-4e26-b5a8-d8d0f3cd4ccd)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
