### PR TITLE
Use plugin bom 5933.vcf06f7b_5d1a_2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5888.vd99c2b_38128d</version>
+        <version>5933.vcf06f7b_5d1a_2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Use plugin bom 5933.vcf06f7b_5d1a_2

Most recent release of plugin BOM.  Unclear why dependabot did not propose the upgrade.

### Testing done

Confirmed that automated tests pass with JDK 21 on Linux.  Rely on ci.jenkins.io for Windows and JDK 25 testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
